### PR TITLE
Fix doctests and compilation failure when running mix test.

### DIFF
--- a/lib/periscope.ex
+++ b/lib/periscope.ex
@@ -159,12 +159,11 @@ defmodule Periscope do
     Map.has_key?(route.metadata, :phoenix_live_view)
   end
 
-
-  @doc~S"""
+  @doc ~S"""
   Merges maps. If a key has different values in each map, they are aggregated into a list.
 
   ## Examples
-    iex> aggregate_merge(%{a: 1, b: [2, 3], c: [4]}, %{a: [5, 6], b: 7, c: [8, 9, 10, 11]})
+    iex> Periscope.aggregate_merge(%{a: 1, b: [2, 3], c: [4]}, %{a: [5, 6], b: 7, c: [8, 9, 10, 11]})
     %{a: [1, 5, 6], b: [2, 3, 7], c: [4, 8, 9, 10, 11]}
   """
 

--- a/test/periscope_test.exs
+++ b/test/periscope_test.exs
@@ -1,8 +1,4 @@
 defmodule PeriscopeTest do
   use ExUnit.Case
   doctest Periscope
-
-  test "greets the world" do
-    assert Periscope.hello() == :world
-  end
 end


### PR DESCRIPTION
Hello @caleb-bb , how is it going?
Great job on this neat little library. Pretty useful idea right there.

I wanted to help you with the #1 typespecs issue and upon cloning the repo and running `mix test` I got:
```
$ mix test                                                
                                                                                                                                                                         
== Compilation error in file test/periscope_test.exs ==                                                                                                                  
** (CompileError) (for doctest at) lib/periscope.ex:167: undefined function aggregate_merge/2 (expected PeriscopeTest to define such a function or for it to be imported,
 but none are available)
  ```
  
  This PR fixes that compilation error.
  I also yanked the default generated test as it would fail since that `hello` function don't exists anymore.
  
  
  In a different matter, shouldn't this `aggregate_merge/2` be a private function though?
  
  Let me know if you see any issues here.
  
 Have a good one and again, good job on the library.
  
  
  