### PR TITLE
Rename unreachable function. Silence compilation warnings.

### DIFF
--- a/lib/periscope.ex
+++ b/lib/periscope.ex
@@ -111,19 +111,14 @@ defmodule Periscope do
     |> liveviews_to_paths()
   end
 
-  # This could be a private function?
-  def liveviews_to_paths(your_app_web) do
+  defp liveviews_to_paths(your_app_web) do
     your_app_web.__routes__()
     |> Enum.filter(&is_a_liveview_route?/1)
     |> Enum.map(&liveview_route_to_path/1)
     |> Enum.reduce(%{}, &aggregate_merge(&1, &2))
   end
-
-  @doc ~S"""
-  Takes a route, extracts the liveview module and path to same, and maps the module to a list containing just that path.
-  """
-  # This could be a private function?
-  def liveview_route_to_path(route) do
+  
+  defp liveview_route_to_path(route) do
     {liveview, path} = {
       route.metadata.phoenix_live_view |> elem(0),
       route.path

--- a/lib/periscope.ex
+++ b/lib/periscope.ex
@@ -24,9 +24,7 @@ defmodule Periscope do
     |> Enum.map(&elem(&1, 0))
   end
 
-  @doc ~S"""
-  Helper function for extracting state from a list of pids.
-  """
+  # Helper function for extracting state from a list of pids.
   defp component_states do
     Enum.map(liveview_pids(), &:sys.get_state/1)
   end
@@ -113,11 +111,25 @@ defmodule Periscope do
     |> liveviews_to_paths()
   end
 
+  # This could be a private function?
   def liveviews_to_paths(your_app_web) do
     your_app_web.__routes__()
     |> Enum.filter(&is_a_liveview_route?/1)
-    |> Enum.map(&liveviews_to_paths/1)
+    |> Enum.map(&liveview_route_to_path/1)
     |> Enum.reduce(%{}, &aggregate_merge(&1, &2))
+  end
+
+  @doc ~S"""
+  Takes a route, extracts the liveview module and path to same, and maps the module to a list containing just that path.
+  """
+  # This could be a private function?
+  def liveview_route_to_path(route) do
+    {liveview, path} = {
+      route.metadata.phoenix_live_view |> elem(0),
+      route.path
+    }
+
+    %{liveview => [path]}
   end
 
   @doc ~S"""
@@ -141,26 +153,13 @@ defmodule Periscope do
   end
 
   @doc ~S"""
-  Takes a route, extracts the liveview module and path to same, and maps the module to a list containing just that path.
-  """
-  def liveviews_to_paths(route) do
-    {liveview, path} = {
-      route.metadata.phoenix_live_view |> elem(0),
-      route.path
-    }
-
-    %{liveview => [path]}
-  end
-
-  @doc ~S"""
   Takes a route and returns true if it's a route to a liveview module.
   """
   def is_a_liveview_route?(route) do
     Map.has_key?(route.metadata, :phoenix_live_view)
   end
 
-
-  @doc~S"""
+  @doc ~S"""
   Merges maps. If a key has different values in each map, they are aggregated into a list.
 
   ## Examples


### PR DESCRIPTION
Hello again @caleb-bb .
This one addresses some other compilation warnings that are raised:
```
warning: defp component_states/0 is private, @doc attribute is always discarded for private functions/macros/types
  lib/periscope.ex:27: Periscope.component_states/0

warning: clauses with the same name and arity (number of arguments) should be grouped together, "def liveviews_to_paths/1" was previously defined (lib/periscope.ex:116)
  lib/periscope.ex:146

warning: this clause for liveviews_to_paths/1 cannot match because a previous clause at line 116 always matches
  lib/periscope.ex:146
```

For the first one, I kept the doc as a comment since it's pointless to have it as a doc string. We're just getting an warning, there is no effect when reading the docs from, say hexdocs. I left it as a comment so others can benefit from your explanation. Let me know if you'd prefer to completely remove it.

Second and third one are somewhat connected.
I renamed the `liveviews_to_paths/1` defined on line 146 to `liveview_route_to_path/1` as it was my understanding from what was going on there.
Even if you prefer another name, please note that the function definition in line 146 is never going to be called.
Both definitions of `liveviews_to_paths/1` are the same in Elixir's eye, so it will always try to run the first definition.
If you want to have the same name and arity, you'll need a guard clause on those variables so Elixir can point to the correct one depending on the argument it receives.

Let me know how you'd prefer to handle this.


Please note that I also left some comments that were meant as a question to you but I don't they should be merged.
So before/if accepting this, let me know so I can clean them up.


Have a good one.

Cheers.