### PR TITLE
Privatize function, fix  app name error

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Periscope can be installed by adding `periscope` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:periscope, "~> 0.4.5"}
+    {:periscope, "~> 0.4.6"}
   ]
 end
 ```

--- a/lib/periscope.ex
+++ b/lib/periscope.ex
@@ -102,10 +102,10 @@ defmodule Periscope do
 
     lib_dir
     |> Enum.filter(&String.ends_with?(&1, "web"))
-    |> hd()
     |> String.split("_")
-    |> hd()
-    |> String.capitalize()
+    |> Enum.drop(-1)
+    |> Enum.map(&String.capitalize(&1))
+    |> Enum.join
   end
 
   @doc ~S"""

--- a/lib/periscope.ex
+++ b/lib/periscope.ex
@@ -165,16 +165,7 @@ defmodule Periscope do
     Map.has_key?(route.metadata, :phoenix_live_view)
   end
 
-  @doc ~S"""
-  Merges maps. If a key has different values in each map, they are aggregated into a list.
-
-  ## Examples
-    iex> Periscope.aggregate_merge(%{a: 1, b: [2, 3], c: [4]}, %{a: [5, 6], b: 7, c: [8, 9, 10, 11]})
-    %{a: [1, 5, 6], b: [2, 3, 7], c: [4, 8, 9, 10, 11]}
-  """
-
-  @spec aggregate_merge(map, map) :: map
-  def aggregate_merge(a, b) do
+  defp aggregate_merge(a, b) do
     Map.merge(a, b, fn _k, v1, v2 -> List.flatten([v1, v2]) end)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Periscope.MixProject do
   def project do
     [
       app: :periscope,
-      version: "0.4.5",
+      version: "0.4.6",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
`application_name/0` throws an error for apps with multiple underscores in their names. Fixed that.